### PR TITLE
Adding an event handler blocker to postMessage

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,11 +1,12 @@
 const port = chrome.runtime.connect(null, { name: "content" });
-    port.onDisconnect.addListener(() => port = null);
+port.onDisconnect.addListener(() => port = null);
+port.postMessage({type: 'RELOAD'}, "*");
 
-    port.postMessage({type: 'RELOAD'})
-
-addEventListener('message', ({data, source}) => {
+addEventListener('message', async {data, source} => {
     if (source !== window || !data || typeof data !== 'object' || data.source !== 'rxjs-watcher') {
         return;
     }
-    port.postMessage(data.message);
+    port.postMessage(data.message, "*");
+
+    await new Promise(resolve => setTimeout(resolve, 100));
 });


### PR DESCRIPTION
Adding an event handler blocker so postMessage gets a target correctly due to handler completing before postMessage firing.

As Jest on Angular uses https://github.com/thymikee/jest-preset-angular, any unit test using Jest in Angular will require https://www.npmjs.com/package/jest-environment-jsdom-fifteen to successfully execute as a dependency. This in turn depends on jsdom, specifically their own implementation of postMessage in this file: https://github.com/jsdom/jsdom/blob/eca4167b171709b085e0d81962963f30ed165133/lib/jsdom/living/post-message.js

Basically, the wrapping event handler needs to have a minor delay that's larger than 0 in order to execute postMessage BEFORE the event handler is completed otherwise the target of the event handler is undefined when postMessage executes on it (as logged out of https://github.com/jsdom/jsdom/blob/8bf2132b69316c2f8e95358bbcd2a199fbaf2a35/lib/jsdom/living/helpers/events.js#L13):

![image](https://user-images.githubusercontent.com/3462199/69035313-79226e00-0a37-11ea-8f2f-74808e9b75a5.png)

jsdom follows the correct implementation, from https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage:
```
postMessage() schedules the MessageEvent to be dispatched only after all pending execution 
contexts have finished. For example, if postMessage() is invoked in an event handler, 
that event handler will run to completion, as will any remaining handlers for that same 
event, before the MessageEvent is dispatched.
```
and this has already been raised within jsdom and explained in https://github.com/jsdom/jsdom/issues/2245